### PR TITLE
Fixed Client Credentials Flow authentication query.

### DIFF
--- a/sdk/src/main/java/com/vk/api/sdk/client/ApiRequest.java
+++ b/sdk/src/main/java/com/vk/api/sdk/client/ApiRequest.java
@@ -77,6 +77,11 @@ public abstract class ApiRequest<T> {
         }
 
         JsonElement response = json.get("response");
+
+        if (!json.has("response")) { // for Client Credentials Flow response
+            response = json;
+        }
+
         try {
             return gson.fromJson(response, responseClass);
         } catch (JsonSyntaxException e) {

--- a/sdk/src/main/java/com/vk/api/sdk/queries/oauth/OAuthServerClientCredentialsFlowQuery.java
+++ b/sdk/src/main/java/com/vk/api/sdk/queries/oauth/OAuthServerClientCredentialsFlowQuery.java
@@ -3,6 +3,7 @@ package com.vk.api.sdk.queries.oauth;
 import com.vk.api.sdk.client.AbstractQueryBuilder;
 import com.vk.api.sdk.client.VkApiClient;
 import com.vk.api.sdk.objects.AuthResponse;
+import com.vk.api.sdk.objects.ClientCredentialsFlowResponse;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -10,10 +11,10 @@ import java.util.Collection;
 /**
  * Created by tsivarev on 22.07.16.
  */
-public class OAuthServerClientCredentialsFlowQuery extends AbstractQueryBuilder<OAuthServerClientCredentialsFlowQuery, AuthResponse> {
+public class OAuthServerClientCredentialsFlowQuery extends AbstractQueryBuilder<OAuthServerClientCredentialsFlowQuery, ClientCredentialsFlowResponse> {
 
     public OAuthServerClientCredentialsFlowQuery(VkApiClient client, String endpoint, Integer clientId, String clientSecret) {
-        super(client, endpoint, "access_token", AuthResponse.class);
+        super(client, endpoint, "access_token", ClientCredentialsFlowResponse.class);
         clientId(clientId);
         clientSecret(clientSecret);
         grantType("client_credentials");
@@ -38,6 +39,6 @@ public class OAuthServerClientCredentialsFlowQuery extends AbstractQueryBuilder<
 
     @Override
     protected Collection<String> essentialKeys() {
-        return Arrays.asList("client_id", "client_secret", "redirect_uri", "code");
+        return Arrays.asList("client_id", "client_secret");
     }
 }


### PR DESCRIPTION
- Removed unnecessary query params
- Fixed response class in query
- Added quick workaround (hack) to fix processing of  Client Credentials Flow response (which doesn't contain "response" field in JSON schema).