### PR TITLE
Added code to support Secure queries.

### DIFF
--- a/sdk/src/main/java/com/vk/api/sdk/client/actors/ServiceActor.java
+++ b/sdk/src/main/java/com/vk/api/sdk/client/actors/ServiceActor.java
@@ -9,11 +9,18 @@ public class ServiceActor implements Actor {
 
     private Integer appId;
 
+    private String clientSecret;
+
     private String accessToken;
 
-    public ServiceActor(Integer appId, String accessToken) {
+    public ServiceActor(Integer appId, String clientSecret, String accessToken) {
         this.accessToken = accessToken;
         this.appId = appId;
+        this.clientSecret = clientSecret;
+    }
+
+    public String getClientSecret() {
+        return clientSecret;
     }
 
     @Override
@@ -32,18 +39,20 @@ public class ServiceActor implements Actor {
         if (o == null || getClass() != o.getClass()) return false;
         ServiceActor that = (ServiceActor) o;
         return Objects.equals(appId, that.appId) &&
+                Objects.equals(clientSecret, that.clientSecret) &&
                 Objects.equals(accessToken, that.accessToken);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(appId, accessToken);
+        return Objects.hash(appId, clientSecret, accessToken);
     }
 
     @Override
     public String toString() {
         final StringBuilder sb = new StringBuilder("ServiceActor{");
         sb.append("appId=").append(appId);
+        sb.append(", clientSecret='").append(clientSecret).append('\'');
         sb.append(", accessToken='").append(accessToken).append('\'');
         sb.append('}');
         return sb.toString();

--- a/sdk/src/main/java/com/vk/api/sdk/queries/secure/AbstractSecureQueryBuilder.java
+++ b/sdk/src/main/java/com/vk/api/sdk/queries/secure/AbstractSecureQueryBuilder.java
@@ -1,0 +1,33 @@
+package com.vk.api.sdk.queries.secure;
+
+import com.vk.api.sdk.client.AbstractQueryBuilder;
+import com.vk.api.sdk.client.VkApiClient;
+
+import java.lang.reflect.Type;
+
+/**
+ * Abstract query builder for Secure methods
+ *
+ * @see "https://vk.com/dev/secure"
+ * Created by AnatoliyS on 21.10.16.
+ */
+public abstract class AbstractSecureQueryBuilder<T, R> extends AbstractQueryBuilder<T, R> {
+
+    public AbstractSecureQueryBuilder(VkApiClient client, String endpoint, String method, Type type) {
+        super(client, endpoint, method, type);
+    }
+
+    public AbstractSecureQueryBuilder(VkApiClient client, String method, Type type) {
+        super(client, method, type);
+    }
+
+    /**
+     * Set "client secret"
+     *
+     * @param value client secret
+     * @return a reference to this {@code AbstractQueryBuilder} object to fulfill the "Builder" pattern.
+     */
+    protected T clientSecret(String value) {
+        return unsafeParam("client_secret", value);
+    }
+}

--- a/sdk/src/main/java/com/vk/api/sdk/queries/secure/SecureAddAppEventQuery.java
+++ b/sdk/src/main/java/com/vk/api/sdk/queries/secure/SecureAddAppEventQuery.java
@@ -11,7 +11,7 @@ import java.util.List;
 /**
  * Query for Secure.addAppEvent method
  */
-public class SecureAddAppEventQuery extends AbstractQueryBuilder<SecureAddAppEventQuery, OkResponse> {
+public class SecureAddAppEventQuery extends AbstractSecureQueryBuilder<SecureAddAppEventQuery, OkResponse> {
     /**
      * Creates a AbstractQueryBuilder instance that can be used to build api request with various parameters
      *
@@ -23,6 +23,7 @@ public class SecureAddAppEventQuery extends AbstractQueryBuilder<SecureAddAppEve
     public SecureAddAppEventQuery(VkApiClient client, ServiceActor actor, int userId, int activityId) {
         super(client, "secure.addAppEvent", OkResponse.class);
         accessToken(actor.getAccessToken());
+        clientSecret(actor.getClientSecret());
         userId(userId);
         activityId(activityId);
     }
@@ -71,6 +72,6 @@ public class SecureAddAppEventQuery extends AbstractQueryBuilder<SecureAddAppEve
 
     @Override
     protected List<String> essentialKeys() {
-        return Arrays.asList("activity_id", "user_id", "access_token");
+        return Arrays.asList("activity_id", "user_id", "access_token", "client_secret");
     }
 }

--- a/sdk/src/main/java/com/vk/api/sdk/queries/secure/SecureCheckTokenQuery.java
+++ b/sdk/src/main/java/com/vk/api/sdk/queries/secure/SecureCheckTokenQuery.java
@@ -1,6 +1,5 @@
 package com.vk.api.sdk.queries.secure;
 
-import com.vk.api.sdk.client.AbstractQueryBuilder;
 import com.vk.api.sdk.client.VkApiClient;
 import com.vk.api.sdk.client.actors.ServiceActor;
 import com.vk.api.sdk.objects.secure.TokenChecked;
@@ -11,7 +10,7 @@ import java.util.List;
 /**
  * Query for Secure.checkToken method
  */
-public class SecureCheckTokenQuery extends AbstractQueryBuilder<SecureCheckTokenQuery, TokenChecked> {
+public class SecureCheckTokenQuery extends AbstractSecureQueryBuilder<SecureCheckTokenQuery, TokenChecked> {
     /**
      * Creates a AbstractQueryBuilder instance that can be used to build api request with various parameters
      *
@@ -21,6 +20,7 @@ public class SecureCheckTokenQuery extends AbstractQueryBuilder<SecureCheckToken
     public SecureCheckTokenQuery(VkApiClient client, ServiceActor actor) {
         super(client, "secure.checkToken", TokenChecked.class);
         accessToken(actor.getAccessToken());
+        clientSecret(actor.getClientSecret());
     }
 
     /**
@@ -51,6 +51,6 @@ public class SecureCheckTokenQuery extends AbstractQueryBuilder<SecureCheckToken
 
     @Override
     protected List<String> essentialKeys() {
-        return Arrays.asList("access_token");
+        return Arrays.asList("access_token", "client_secret");
     }
 }

--- a/sdk/src/main/java/com/vk/api/sdk/queries/secure/SecureGetAppBalanceQuery.java
+++ b/sdk/src/main/java/com/vk/api/sdk/queries/secure/SecureGetAppBalanceQuery.java
@@ -10,7 +10,7 @@ import java.util.List;
 /**
  * Query for Secure.getAppBalance method
  */
-public class SecureGetAppBalanceQuery extends AbstractQueryBuilder<SecureGetAppBalanceQuery, Integer> {
+public class SecureGetAppBalanceQuery extends AbstractSecureQueryBuilder<SecureGetAppBalanceQuery, Integer> {
     /**
      * Creates a AbstractQueryBuilder instance that can be used to build api request with various parameters
      *
@@ -20,6 +20,7 @@ public class SecureGetAppBalanceQuery extends AbstractQueryBuilder<SecureGetAppB
     public SecureGetAppBalanceQuery(VkApiClient client, ServiceActor actor) {
         super(client, "secure.getAppBalance", Integer.class);
         accessToken(actor.getAccessToken());
+        clientSecret(actor.getClientSecret());
     }
 
     @Override
@@ -29,6 +30,6 @@ public class SecureGetAppBalanceQuery extends AbstractQueryBuilder<SecureGetAppB
 
     @Override
     protected List<String> essentialKeys() {
-        return Arrays.asList("access_token");
+        return Arrays.asList("access_token", "client_secret");
     }
 }

--- a/sdk/src/main/java/com/vk/api/sdk/queries/secure/SecureGetSMSHistoryQuery.java
+++ b/sdk/src/main/java/com/vk/api/sdk/queries/secure/SecureGetSMSHistoryQuery.java
@@ -12,7 +12,7 @@ import java.util.List;
 /**
  * Query for Secure.getSMSHistory method
  */
-public class SecureGetSMSHistoryQuery extends AbstractQueryBuilder<SecureGetSMSHistoryQuery, List<SmsNotification>> {
+public class SecureGetSMSHistoryQuery extends AbstractSecureQueryBuilder<SecureGetSMSHistoryQuery, List<SmsNotification>> {
     /**
      * Creates a AbstractQueryBuilder instance that can be used to build api request with various parameters
      *
@@ -22,6 +22,7 @@ public class SecureGetSMSHistoryQuery extends AbstractQueryBuilder<SecureGetSMSH
     public SecureGetSMSHistoryQuery(VkApiClient client, ServiceActor actor) {
         super(client, "secure.getSMSHistory", Utils.buildParametrizedType(List.class, SmsNotification.class));
         accessToken(actor.getAccessToken());
+        clientSecret(actor.getClientSecret());
     }
 
     /**
@@ -71,6 +72,6 @@ public class SecureGetSMSHistoryQuery extends AbstractQueryBuilder<SecureGetSMSH
 
     @Override
     protected List<String> essentialKeys() {
-        return Arrays.asList("access_token");
+        return Arrays.asList("access_token", "client_secret");
     }
 }

--- a/sdk/src/main/java/com/vk/api/sdk/queries/secure/SecureGetTransactionsHistoryQuery.java
+++ b/sdk/src/main/java/com/vk/api/sdk/queries/secure/SecureGetTransactionsHistoryQuery.java
@@ -12,7 +12,7 @@ import java.util.List;
 /**
  * Query for Secure.getTransactionsHistory method
  */
-public class SecureGetTransactionsHistoryQuery extends AbstractQueryBuilder<SecureGetTransactionsHistoryQuery, List<Transaction>> {
+public class SecureGetTransactionsHistoryQuery extends AbstractSecureQueryBuilder<SecureGetTransactionsHistoryQuery, List<Transaction>> {
     /**
      * Creates a AbstractQueryBuilder instance that can be used to build api request with various parameters
      *
@@ -22,6 +22,7 @@ public class SecureGetTransactionsHistoryQuery extends AbstractQueryBuilder<Secu
     public SecureGetTransactionsHistoryQuery(VkApiClient client, ServiceActor actor) {
         super(client, "secure.getTransactionsHistory", Utils.buildParametrizedType(List.class, Transaction.class));
         accessToken(actor.getAccessToken());
+        clientSecret(actor.getClientSecret());
     }
 
     @Override
@@ -31,6 +32,6 @@ public class SecureGetTransactionsHistoryQuery extends AbstractQueryBuilder<Secu
 
     @Override
     protected List<String> essentialKeys() {
-        return Arrays.asList("access_token");
+        return Arrays.asList("access_token", "client_secret");
     }
 }

--- a/sdk/src/main/java/com/vk/api/sdk/queries/secure/SecureGetUserLevelQuery.java
+++ b/sdk/src/main/java/com/vk/api/sdk/queries/secure/SecureGetUserLevelQuery.java
@@ -12,7 +12,7 @@ import java.util.List;
 /**
  * Query for Secure.getUserLevel method
  */
-public class SecureGetUserLevelQuery extends AbstractQueryBuilder<SecureGetUserLevelQuery, List<Level>> {
+public class SecureGetUserLevelQuery extends AbstractSecureQueryBuilder<SecureGetUserLevelQuery, List<Level>> {
     /**
      * Creates a AbstractQueryBuilder instance that can be used to build api request with various parameters
      *
@@ -23,6 +23,7 @@ public class SecureGetUserLevelQuery extends AbstractQueryBuilder<SecureGetUserL
     public SecureGetUserLevelQuery(VkApiClient client, ServiceActor actor, int... userIds) {
         super(client, "secure.getUserLevel", Utils.buildParametrizedType(List.class, Level.class));
         accessToken(actor.getAccessToken());
+        clientSecret(actor.getClientSecret());
         userIds(userIds);
     }
 
@@ -66,6 +67,6 @@ public class SecureGetUserLevelQuery extends AbstractQueryBuilder<SecureGetUserL
 
     @Override
     protected List<String> essentialKeys() {
-        return Arrays.asList("user_ids", "access_token");
+        return Arrays.asList("user_ids", "access_token", "client_secret");
     }
 }

--- a/sdk/src/main/java/com/vk/api/sdk/queries/secure/SecureSendNotificationQuery.java
+++ b/sdk/src/main/java/com/vk/api/sdk/queries/secure/SecureSendNotificationQuery.java
@@ -11,7 +11,7 @@ import java.util.List;
 /**
  * Query for Secure.sendNotification method
  */
-public class SecureSendNotificationQuery extends AbstractQueryBuilder<SecureSendNotificationQuery, List<Integer>> {
+public class SecureSendNotificationQuery extends AbstractSecureQueryBuilder<SecureSendNotificationQuery, List<Integer>> {
     /**
      * Creates a AbstractQueryBuilder instance that can be used to build api request with various parameters
      *
@@ -22,6 +22,7 @@ public class SecureSendNotificationQuery extends AbstractQueryBuilder<SecureSend
     public SecureSendNotificationQuery(VkApiClient client, ServiceActor actor, String message) {
         super(client, "secure.sendNotification", Utils.buildParametrizedType(List.class, Integer.class));
         accessToken(actor.getAccessToken());
+        clientSecret(actor.getClientSecret());
         message(message);
     }
 
@@ -73,6 +74,6 @@ public class SecureSendNotificationQuery extends AbstractQueryBuilder<SecureSend
 
     @Override
     protected List<String> essentialKeys() {
-        return Arrays.asList("message", "access_token");
+        return Arrays.asList("message", "access_token", "client_secret");
     }
 }

--- a/sdk/src/main/java/com/vk/api/sdk/queries/secure/SecureSendSMSNotificationQuery.java
+++ b/sdk/src/main/java/com/vk/api/sdk/queries/secure/SecureSendSMSNotificationQuery.java
@@ -11,7 +11,7 @@ import java.util.List;
 /**
  * Query for Secure.sendSMSNotification method
  */
-public class SecureSendSMSNotificationQuery extends AbstractQueryBuilder<SecureSendSMSNotificationQuery, OkResponse> {
+public class SecureSendSMSNotificationQuery extends AbstractSecureQueryBuilder<SecureSendSMSNotificationQuery, OkResponse> {
     /**
      * Creates a AbstractQueryBuilder instance that can be used to build api request with various parameters
      *
@@ -23,6 +23,7 @@ public class SecureSendSMSNotificationQuery extends AbstractQueryBuilder<SecureS
     public SecureSendSMSNotificationQuery(VkApiClient client, ServiceActor actor, int userId, String message) {
         super(client, "secure.sendSMSNotification", OkResponse.class);
         accessToken(actor.getAccessToken());
+        clientSecret(actor.getClientSecret());
         userId(userId);
         message(message);
     }
@@ -54,6 +55,6 @@ public class SecureSendSMSNotificationQuery extends AbstractQueryBuilder<SecureS
 
     @Override
     protected List<String> essentialKeys() {
-        return Arrays.asList("message", "user_id", "access_token");
+        return Arrays.asList("message", "user_id", "access_token", "client_secret");
     }
 }

--- a/sdk/src/main/java/com/vk/api/sdk/queries/secure/SecureSetCounterQuery.java
+++ b/sdk/src/main/java/com/vk/api/sdk/queries/secure/SecureSetCounterQuery.java
@@ -11,7 +11,7 @@ import java.util.List;
 /**
  * Query for Secure.setCounter method
  */
-public class SecureSetCounterQuery extends AbstractQueryBuilder<SecureSetCounterQuery, OkResponse> {
+public class SecureSetCounterQuery extends AbstractSecureQueryBuilder<SecureSetCounterQuery, OkResponse> {
     /**
      * Creates a AbstractQueryBuilder instance that can be used to build api request with various parameters
      *
@@ -21,6 +21,7 @@ public class SecureSetCounterQuery extends AbstractQueryBuilder<SecureSetCounter
     public SecureSetCounterQuery(VkApiClient client, ServiceActor actor) {
         super(client, "secure.setCounter", OkResponse.class);
         accessToken(actor.getAccessToken());
+        clientSecret(actor.getClientSecret());
     }
 
     /**
@@ -70,6 +71,6 @@ public class SecureSetCounterQuery extends AbstractQueryBuilder<SecureSetCounter
 
     @Override
     protected List<String> essentialKeys() {
-        return Arrays.asList("access_token");
+        return Arrays.asList("access_token", "client_secret");
     }
 }

--- a/sdk/src/main/java/com/vk/api/sdk/queries/secure/SecureSetUserLevelQuery.java
+++ b/sdk/src/main/java/com/vk/api/sdk/queries/secure/SecureSetUserLevelQuery.java
@@ -11,7 +11,7 @@ import java.util.List;
 /**
  * Query for Secure.setUserLevel method
  */
-public class SecureSetUserLevelQuery extends AbstractQueryBuilder<SecureSetUserLevelQuery, OkResponse> {
+public class SecureSetUserLevelQuery extends AbstractSecureQueryBuilder<SecureSetUserLevelQuery, OkResponse> {
     /**
      * Creates a AbstractQueryBuilder instance that can be used to build api request with various parameters
      *
@@ -21,6 +21,7 @@ public class SecureSetUserLevelQuery extends AbstractQueryBuilder<SecureSetUserL
     public SecureSetUserLevelQuery(VkApiClient client, ServiceActor actor) {
         super(client, "secure.setUserLevel", OkResponse.class);
         accessToken(actor.getAccessToken());
+        clientSecret(actor.getClientSecret());
     }
 
     /**
@@ -70,6 +71,6 @@ public class SecureSetUserLevelQuery extends AbstractQueryBuilder<SecureSetUserL
 
     @Override
     protected List<String> essentialKeys() {
-        return Arrays.asList("access_token");
+        return Arrays.asList("access_token", "client_secret");
     }
 }


### PR DESCRIPTION
Right now secure queries don't work, because they require "client_secret" parameter. This commit is aimed to fix it.

- Added "client_secret" field for ServiceActor
- Added abstract builder for such queries. This class allows setting "client_secret" parameter, which is necessary for all secure queries
- Added "client_secret" parameter to "essential keys" lists

So for SDK user the procedure is clear :
1) Create ServiceActor, which has "client_secret" parameter in constructor
2) Create any secure queries, using ServiceActor, without a need to set "client_secret" parameter manually. It is already set automatically in query constructor

Adding additional abstract SecureQueryBuilder allows to make concrete query classes more lightweight, removes duplication (code that sets "client secret" parameter) and also makes code in concrete query's constructor easy to understand (we set "client_secret" in the same fashion as we set "access_token")