### PR TITLE
Type fix in LinksItem for name and editTitle

### DIFF
--- a/sdk/src/main/java/com/vk/api/sdk/objects/groups/LinksItem.java
+++ b/sdk/src/main/java/com/vk/api/sdk/objects/groups/LinksItem.java
@@ -24,7 +24,7 @@ public class LinksItem {
      * Information whether the link title can be edited
      */
     @SerializedName("edit_title")
-    private String editTitle;
+    private Integer editTitle;
 
     /**
      * Link title
@@ -58,7 +58,7 @@ public class LinksItem {
         return url;
     }
 
-    public String getEditTitle() {
+    public Integer getEditTitle() {
         return editTitle;
     }
 
@@ -103,7 +103,7 @@ public class LinksItem {
         sb.append("id=").append(id);
         sb.append(", url='").append(url).append("'");
         sb.append(", editTitle=").append(editTitle);
-        sb.append(", name=").append(name);
+        sb.append(", name='").append(name).append("'");
         sb.append(", desc='").append(desc).append("'");
         sb.append(", photo50='").append(photo50).append("'");
         sb.append(", photo100='").append(photo100).append("'");

--- a/sdk/src/main/java/com/vk/api/sdk/objects/groups/LinksItem.java
+++ b/sdk/src/main/java/com/vk/api/sdk/objects/groups/LinksItem.java
@@ -24,13 +24,13 @@ public class LinksItem {
      * Information whether the link title can be edited
      */
     @SerializedName("edit_title")
-    private Integer editTitle;
+    private String editTitle;
 
     /**
      * Link title
      */
     @SerializedName("name")
-    private Integer name;
+    private String name;
 
     /**
      * Link description
@@ -58,11 +58,11 @@ public class LinksItem {
         return url;
     }
 
-    public Integer getEditTitle() {
+    public String getEditTitle() {
         return editTitle;
     }
 
-    public Integer getName() {
+    public String getName() {
         return name;
     }
 


### PR DESCRIPTION
When fetching group with field links, deserialization fails because of name and editTitle fields in LinksItem which are Integers instead of Strings.