### PR TITLE
PhotosSaveOwnerCoverPhotoQuery в ответе имеет не Array а объект

### DIFF
--- a/sdk/src/main/java/com/vk/api/sdk/objects/photos/responses/PhotosSaveOwnerCoverPhotoResponse.java
+++ b/sdk/src/main/java/com/vk/api/sdk/objects/photos/responses/PhotosSaveOwnerCoverPhotoResponse.java
@@ -1,0 +1,45 @@
+package com.vk.api.sdk.objects.photos.responses;
+
+import com.google.gson.annotations.SerializedName;
+import com.vk.api.sdk.objects.base.Image;
+
+import java.util.List;
+
+/**
+ * Created by yuriy.dorofeev on 13.04.17.
+ * </p>
+ */
+public class PhotosSaveOwnerCoverPhotoResponse {
+    /**
+     * Images list
+     */
+    @SerializedName("images")
+    private List<Image> images;
+
+    public List<Image> getImages() {
+        return images;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        PhotosSaveOwnerCoverPhotoResponse that = (PhotosSaveOwnerCoverPhotoResponse) o;
+
+        return images != null ? images.equals(that.images) : that.images == null;
+    }
+
+    @Override
+    public int hashCode() {
+        return images != null ? images.hashCode() : 0;
+    }
+
+    @Override
+    public String toString() {
+        final StringBuilder sb = new StringBuilder("PhotosSaveOwnerCoverPhotoResponse{");
+        sb.append("images=").append(images);
+        sb.append('}');
+        return sb.toString();
+    }
+}

--- a/sdk/src/main/java/com/vk/api/sdk/queries/photos/PhotosSaveOwnerCoverPhotoQuery.java
+++ b/sdk/src/main/java/com/vk/api/sdk/queries/photos/PhotosSaveOwnerCoverPhotoQuery.java
@@ -6,6 +6,7 @@ import com.vk.api.sdk.client.VkApiClient;
 import com.vk.api.sdk.client.actors.GroupActor;
 import com.vk.api.sdk.client.actors.UserActor;
 import com.vk.api.sdk.objects.base.Image;
+import com.vk.api.sdk.objects.photos.responses.PhotosSaveOwnerCoverPhotoResponse;
 
 import java.util.Arrays;
 import java.util.List;
@@ -13,7 +14,7 @@ import java.util.List;
 /**
  * Query for Photos.saveOwnerCoverPhoto method
  */
-public class PhotosSaveOwnerCoverPhotoQuery extends AbstractQueryBuilder<PhotosSaveOwnerCoverPhotoQuery, List<Image>> {
+public class PhotosSaveOwnerCoverPhotoQuery extends AbstractQueryBuilder<PhotosSaveOwnerCoverPhotoQuery, PhotosSaveOwnerCoverPhotoResponse> {
 
     /**
      * Creates a AbstractQueryBuilder instance that can be used to build api request with various parameters
@@ -22,7 +23,7 @@ public class PhotosSaveOwnerCoverPhotoQuery extends AbstractQueryBuilder<PhotosS
      * @param actor  actor with access token
      */
     public PhotosSaveOwnerCoverPhotoQuery(VkApiClient client, UserActor actor, String photo, String hash) {
-        super(client, "photos.saveOwnerCoverPhoto", Utils.buildParametrizedType(List.class, Image.class));
+        super(client, "photos.saveOwnerCoverPhoto", PhotosSaveOwnerCoverPhotoResponse.class);
         accessToken(actor.getAccessToken());
         photo(photo);
         hash(hash);
@@ -35,7 +36,7 @@ public class PhotosSaveOwnerCoverPhotoQuery extends AbstractQueryBuilder<PhotosS
      * @param actor  actor with access token
      */
     public PhotosSaveOwnerCoverPhotoQuery(VkApiClient client, GroupActor actor, String photo, String hash) {
-        super(client, "photos.saveOwnerCoverPhoto", Utils.buildParametrizedType(List.class, Image.class));
+        super(client, "photos.saveOwnerCoverPhoto", PhotosSaveOwnerCoverPhotoResponse.class);
         accessToken(actor.getAccessToken());
         photo(photo);
         hash(hash);


### PR DESCRIPTION
На выполнение PhotosSaveOwnerCoverPhotoQuery приходит ответ : `{"response":{"images":[{..]}}`. Array вложен в объект.
Создал PhotosSaveOwnerCoverPhotoResponse для корректной работы