### PR TITLE
Fix delete call typo witch leads to StackOverflowError

### DIFF
--- a/sdk/src/main/java/com/vk/api/sdk/httpclient/HttpTransportClient.java
+++ b/sdk/src/main/java/com/vk/api/sdk/httpclient/HttpTransportClient.java
@@ -256,7 +256,7 @@ public class HttpTransportClient implements TransportClient {
 
     @Override
     public ClientResponse delete(String url) throws IOException {
-        return delete(url);
+        return delete(url, null);
     }
 
     @Override


### PR DESCRIPTION
`HttpTransportClient::delete` method just recursively calls itself. It has no condition for breaking call, so once method was called `StackOverflowError` guaranteed to be thrown.
Probably there are was a typo, and this method should call overload of itself with `null` body.