### PR TITLE
Message POJO serialized name renamed to body from text

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,7 +345,7 @@ Override methods from CallbackApi class for handling events
 public class CallbackApiHandler extends CallbackApi {
   @Override
   public void messageNew(Integer groupId, Message message) {
-    System.out.println(message.getBody());
+    System.out.println(message.getText());
   }
 }
 ```

--- a/sdk/src/main/java/com/vk/api/sdk/objects/messages/Message.java
+++ b/sdk/src/main/java/com/vk/api/sdk/objects/messages/Message.java
@@ -118,7 +118,7 @@ public class Message implements Validable {
     /**
      * Message text
      */
-    @SerializedName("text")
+    @SerializedName("body")
     @Required
     private String text;
 


### PR DESCRIPTION
Я столкнулся с этой проблемой когда пытался использовать `CallbackApiLongPoll`

Дело в том, что в методе:
```java
    public void messageNew(Integer groupId, Message message) {
        LOG.info("messageNew: " + message.toString());
    }
```

Передается объект `Message`, который по сути является POJO.

В версии до моего пула выводится:
```
2019-08-29 00:03:15 INFO  HttpTransportClient:208 - Request: https://api.vk.com/method/groups.getLongPollSettings		722
2019-08-29 00:03:16 INFO  HttpTransportClient:208 - Request: https://api.vk.com/method/groups.getLongPollServer		155
2019-08-29 00:03:20 INFO  HttpTransportClient:208 - Request: https://lp.vk.com/wh172998024		4665
2019-08-29 00:03:20 WARN  OAuthQueryBuilder:458 - Unsupported callback event
2019-08-29 00:03:22 INFO  HttpTransportClient:208 - Request: https://lp.vk.com/wh172998024		1458
2019-08-29 00:03:22 INFO  CallbackApiLongPollHandler:31 - messageNew: {"date":1567004602,"id":8824,"out":"0"}
```

Затем я изменил значение `@SerializedName("text")` на `@SerializedName("body")` :
```
2019-08-29 00:04:41 INFO  HttpTransportClient:208 - Request: https://api.vk.com/method/groups.getLongPollSettings		807
2019-08-29 00:04:41 INFO  HttpTransportClient:208 - Request: https://api.vk.com/method/groups.getLongPollServer		147
2019-08-29 00:04:45 INFO  HttpTransportClient:208 - Request: https://lp.vk.com/wh172998024		3785
2019-08-29 00:04:45 WARN  OAuthQueryBuilder:458 - Unsupported callback event
2019-08-29 00:04:46 INFO  HttpTransportClient:208 - Request: https://lp.vk.com/wh172998024		1363
2019-08-29 00:04:46 INFO  CallbackApiLongPollHandler:31 - messageNew: {"date":1567004686,"id":8825,"out":"0","body":"My message"}
```

Я считаю, что это очень серьезная ошибка, которая требует немедленного решения.

Использовал официальный [пример](https://github.com/VKCOM/vk-java-sdk/tree/master/examples/callback-api-group-bot) из SDK