### PR TITLE
Use User class in friends/responses/GetResponse.response.items instead of Integer

### DIFF
--- a/sdk/src/main/java/com/vk/api/sdk/objects/friends/responses/GetResponse.java
+++ b/sdk/src/main/java/com/vk/api/sdk/objects/friends/responses/GetResponse.java
@@ -4,6 +4,7 @@ import com.google.gson.Gson;
 import com.google.gson.annotations.SerializedName;
 import com.vk.api.sdk.objects.Validable;
 import com.vk.api.sdk.objects.annotations.Required;
+import com.vk.api.sdk.objects.users.User;
 import java.util.List;
 import java.util.Objects;
 
@@ -20,7 +21,7 @@ public class GetResponse implements Validable {
 
     @SerializedName("items")
     @Required
-    private List<Integer> items;
+    private List<User> items;
 
     public Integer getCount() {
         return count;
@@ -31,11 +32,11 @@ public class GetResponse implements Validable {
         return this;
     }
 
-    public List<Integer> getItems() {
+    public List<User> getItems() {
         return items;
     }
 
-    public GetResponse setItems(List<Integer> items) {
+    public GetResponse setItems(List<User> items) {
         this.items = items;
         return this;
     }


### PR DESCRIPTION
It's not really what service really returns, though at least something that includes all fields returned.
Service response format:
```json
{
  "response": {
    "count": 100,
    "items": [
      {
        "id": 1111111,
        "first_name": "Name",
        "last_name": "Surname",
        "is_closed": false,
        "can_access_closed": true,
        "nickname": "",
        "online": 0,
        "track_code": "2db67ed..."
      },
      ...
    ]
  }
}
```

Proposed change is the simplest way to go, though the right way is to create a model for this exact response. Any thoughts?