### PR TITLE
Changed type of url from URL to String

### DIFF
--- a/sdk/src/main/java/com/vk/api/sdk/objects/audio/Audio.java
+++ b/sdk/src/main/java/com/vk/api/sdk/objects/audio/Audio.java
@@ -96,11 +96,11 @@ public class Audio implements Validable {
         return this;
     }
 
-    public URL getUrl() {
+    public String getUrl() {
         return url;
     }
 
-    public Audio setUrl(URL url) {
+    public Audio setUrl(String url) {
         this.url = url;
         return this;
     }

--- a/sdk/src/main/java/com/vk/api/sdk/objects/audio/Audio.java
+++ b/sdk/src/main/java/com/vk/api/sdk/objects/audio/Audio.java
@@ -36,7 +36,7 @@ public class Audio implements Validable {
      * URL of mp3 file
      */
     @SerializedName("url")
-    private URL url;
+    private String url;
 
     /**
      * Duration in seconds


### PR DESCRIPTION
Because some methods like a wall.get return a post with audio in attachments with empty url string, that`s breaks GSON with java.net.MalformedURLException: no protocol: