### PR TITLE
fix CallbackApiLongPoll#getLongPollServer NPE if userActor is null

### DIFF
--- a/sdk/src/main/java/com/vk/api/sdk/callback/longpoll/CallbackApiLongPoll.java
+++ b/sdk/src/main/java/com/vk/api/sdk/callback/longpoll/CallbackApiLongPoll.java
@@ -75,7 +75,7 @@ public class CallbackApiLongPoll extends CallbackApi {
 
     private GetLongPollServerResponse getLongPollServer() throws ClientException, ApiException {
         if (groupActor != null) {
-            client.groupsLongPoll().getLongPollServer(groupActor, groupActor.getGroupId()).execute();
+            return client.groupsLongPoll().getLongPollServer(groupActor, groupActor.getGroupId()).execute();
         }
 
         return client.groupsLongPoll().getLongPollServer(userActor, groupId).execute();


### PR DESCRIPTION
This PR sets back missing return statement, fixes NPE when userActor is null.