### PR TITLE
Fixed handling events message_new, message_reply and message_edit

### DIFF
--- a/examples/youtrack-bot/src/main/java/com/vk/api/examples/youtrack/callback/CallbackApiHandler.java
+++ b/examples/youtrack-bot/src/main/java/com/vk/api/examples/youtrack/callback/CallbackApiHandler.java
@@ -1,6 +1,7 @@
 package com.vk.api.examples.youtrack.callback;
 
 import com.vk.api.sdk.callback.CallbackApi;
+import com.vk.api.sdk.objects.callback.MessageData;
 import com.vk.api.sdk.objects.messages.Message;
 
 /**
@@ -9,7 +10,7 @@ import com.vk.api.sdk.objects.messages.Message;
 public class CallbackApiHandler extends CallbackApi {
 
     @Override
-    public void messageNew(Integer groupId, Message message) {
-        MessagesHandler.parseMessage(groupId, message);
+    public void messageNew(Integer groupId, MessageData message) {
+        MessagesHandler.parseMessage(groupId, message.getMessage());
     }
 }

--- a/sdk/src/main/java/com/vk/api/sdk/callback/CallbackApi.java
+++ b/sdk/src/main/java/com/vk/api/sdk/callback/CallbackApi.java
@@ -71,11 +71,11 @@ public class CallbackApi {
 
     static {
         Map<String, Type> types = new HashMap<>();
-        types.put(CALLBACK_EVENT_MESSAGE_NEW, new TypeToken<CallbackMessage<Message>>() {
+        types.put(CALLBACK_EVENT_MESSAGE_NEW, new TypeToken<CallbackMessage<MessageData>>() {
         }.getType());
-        types.put(CALLBACK_EVENT_MESSAGE_REPLY, new TypeToken<CallbackMessage<Message>>() {
+        types.put(CALLBACK_EVENT_MESSAGE_REPLY, new TypeToken<CallbackMessage<MessageData>>() {
         }.getType());
-        types.put(CALLBACK_EVENT_MESSAGE_EDIT, new TypeToken<CallbackMessage<Message>>() {
+        types.put(CALLBACK_EVENT_MESSAGE_EDIT, new TypeToken<CallbackMessage<MessageData>>() {
         }.getType());
         types.put(CALLBACK_EVENT_MESSAGE_ALLOW, new TypeToken<CallbackMessage<MessageAllow>>() {
         }.getType());
@@ -166,24 +166,24 @@ public class CallbackApi {
         gson = new Gson();
     }
 
-    public void messageNew(Integer groupId, Message message) {
+    public void messageNew(Integer groupId, MessageData message) {
     }
 
-    public void messageNew(Integer groupId, String secret, Message message) {
+    public void messageNew(Integer groupId, String secret, MessageData message) {
         messageNew(groupId, message);
     }
 
-    public void messageReply(Integer groupId, Message message) {
+    public void messageReply(Integer groupId, MessageData message) {
     }
 
-    public void messageReply(Integer groupId, String secret, Message message) {
+    public void messageReply(Integer groupId, String secret, MessageData message) {
         messageReply(groupId, message);
     }
 
-    public void messageEdit(Integer groupId, Message message) {
+    public void messageEdit(Integer groupId, MessageData message) {
     }
 
-    public void messageEdit(Integer groupId, String secret, Message message) {
+    public void messageEdit(Integer groupId, String secret, MessageData message) {
         messageEdit(groupId, message);
     }
 
@@ -463,15 +463,15 @@ public class CallbackApi {
 
         switch (type) {
             case CALLBACK_EVENT_MESSAGE_NEW:
-                messageNew(message.getGroupId(), message.getSecret(), (Message) message.getObject());
+                messageNew(message.getGroupId(), message.getSecret(), (MessageData) message.getObject());
                 break;
 
             case CALLBACK_EVENT_MESSAGE_REPLY:
-                messageReply(message.getGroupId(), message.getSecret(), (Message) message.getObject());
+                messageReply(message.getGroupId(), message.getSecret(), (MessageData) message.getObject());
                 break;
 
             case CALLBACK_EVENT_MESSAGE_EDIT:
-                messageEdit(message.getGroupId(), message.getSecret(), (Message) message.getObject());
+                messageEdit(message.getGroupId(), message.getSecret(), (MessageData) message.getObject());
                 break;
 
             case CALLBACK_EVENT_MESSAGE_ALLOW:

--- a/sdk/src/main/java/com/vk/api/sdk/objects/callback/MessageData.java
+++ b/sdk/src/main/java/com/vk/api/sdk/objects/callback/MessageData.java
@@ -5,6 +5,8 @@ import com.google.gson.JsonObject;
 import com.google.gson.annotations.SerializedName;
 import com.vk.api.sdk.objects.Validable;
 import com.vk.api.sdk.objects.client.InfoForBots;
+import com.vk.api.sdk.objects.messages.Message;
+
 import java.util.Objects;
 
 /**
@@ -15,7 +17,7 @@ public class MessageData implements Validable {
     private InfoForBots clientInfo;
 
     @SerializedName("message")
-    private JsonObject message;
+    private Message message;
 
     public InfoForBots getClientInfo() {
         return clientInfo;
@@ -26,11 +28,11 @@ public class MessageData implements Validable {
         return this;
     }
 
-    public JsonObject getMessage() {
+    public Message getMessage() {
         return message;
     }
 
-    public MessageData setMessage(JsonObject message) {
+    public MessageData setMessage(Message message) {
         this.message = message;
         return this;
     }


### PR DESCRIPTION
Long Poll since 5.103 returns a message object inside a "message" field. This is important because SDK supports 5.130