### PR TITLE
Fix adding two parameters of the same type in the query in the GroupsGetLongPollSettingsQuery constructor

### DIFF
--- a/sdk/src/main/java/com/vk/api/sdk/queries/groups/GroupsGetLongPollSettingsQuery.java
+++ b/sdk/src/main/java/com/vk/api/sdk/queries/groups/GroupsGetLongPollSettingsQuery.java
@@ -36,7 +36,6 @@ public class GroupsGetLongPollSettingsQuery extends AbstractQueryBuilder<GroupsG
     public GroupsGetLongPollSettingsQuery(VkApiClient client, GroupActor actor, int groupId) {
         super(client, "groups.getLongPollSettings", GetLongPollSettingsResponse.class);
         accessToken(actor.getAccessToken());
-        groupId(actor.getGroupId());
         groupId(groupId);
     }
 


### PR DESCRIPTION
#262 fixed