### PR TITLE
fix for longpool

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,17 +363,13 @@ vk.groups().setLongPollSettings(groupActor).enabled(true)
 Override methods from CallbackApiLongPoll class for handling events and create needed constructors
 
 ```java
-public class CallbackApiLongPollHandler extends CallbackApiLongPoll {
-    public CallbackApiLongPollHandler(VkApiClient client, UserActor actor, Integer groupId) {
-      super(client, actor, groupId);
-    }
-
-    public CallbackApiLongPollHandler(VkApiClient client, GroupActor actor) {
-      super(client, actor);
+public class CallbackApiLongPollHandler extends GroupLongPollApi {
+    public CallbackApiLongPollHandler(VkApiClient client, GroupActor actor, int waitTime) {
+      super(client, actor, waitTime);
     }
 
     @Override
-    public void messageNew(Integer groupId, Message message) {
+    public void messageNew(Integer groupId, MessageObject message) {
       System.out.println("messageNew: " + message.toString());
     }
 
@@ -384,7 +380,7 @@ public class CallbackApiLongPollHandler extends CallbackApiLongPoll {
 }
 ```
 
-In order to use the created ```CallbackApiLongPollHandler``` which overrides methods from CallBackApiLongPoll,
+In order to use the created ```CallbackApiLongPollHandler``` which overrides methods from ```GroupLongPollApi```,
 the instance of it needs to be created and method ```run``` called
 
 ```java

--- a/sdk/src/main/java/com/vk/api/sdk/events/Events.java
+++ b/sdk/src/main/java/com/vk/api/sdk/events/Events.java
@@ -15,7 +15,7 @@ import java.lang.reflect.Type;
 public enum Events {
 
     @SerializedName("message_new")
-    MESSAGE_NEW(Message.class),
+    MESSAGE_NEW(MessageObject.class),
 
     @SerializedName("message_reply")
     MESSAGE_REPLY(Message.class),

--- a/sdk/src/main/java/com/vk/api/sdk/events/EventsHandler.java
+++ b/sdk/src/main/java/com/vk/api/sdk/events/EventsHandler.java
@@ -31,7 +31,7 @@ public abstract class EventsHandler {
         return null;
     }
 
-    protected void messageNew(Integer groupId, Message message) {
+    protected void messageNew(Integer groupId, MessageObject message) {
         LOG.error(OVERRIDING_ERR);
     }
 


### PR DESCRIPTION
Message > MessageObject. Not tested properly (works on longpool).